### PR TITLE
iOS 8 Contact Picker selection fix

### DIFF
--- a/src/ios/ContactPicker.m
+++ b/src/ios/ContactPicker.m
@@ -101,6 +101,9 @@ shouldContinueAfterSelectingPerson:(ABRecordRef)person {
     return NO;
 }
 
+- (void)peoplePickerNavigationController:(ABPeoplePickerNavigationController *)peoplePicker didSelectPerson:(ABRecordRef)person{
+    [self peoplePickerNavigationController:peoplePicker shouldContinueAfterSelectingPerson:person];
+}
 
 - (BOOL) personViewController:(ABPersonViewController*)personView shouldPerformDefaultActionForPerson:(ABRecordRef)person property:(ABPropertyID)property identifier:(ABMultiValueIdentifier)identifierForValue
 {


### PR DESCRIPTION
This fixes the issue in iOS 8 where the iOS contact overlay after
getting invoked and when the user selects the desired contact, control
doesn’t return back to the phone gap app.

Source:
http://stackoverflow.com/questions/25806774/abpeoplepickernavigationcont
roller-changes-with-ios8
